### PR TITLE
error with test

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "react-dom": "^0.14.3",
     "react-redux": "^4.0.0",
     "react-router": "^2.0.1",
+    "react-select2-wrapper": "^1.0.4-beta2",
     "redux": "^3.0.4"
   }
 }

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -1,9 +1,14 @@
 import React, { Component } from 'react';
+import Select2 from 'react-select2-wrapper';
 
 export default class App extends Component {
   render() {
     return (
-      <div>React simple starter</div>
+      <div>
+	
+	React simple starter
+	<Select2 />
+	</div>
     );
   }
 }


### PR DESCRIPTION
Running test with Select2 React Wrapper end with errors:

```
npm run test
```

Output
```
Llewellyns-MBP:ReduxSimpleStarter llewellynthomas$ npm run test

> redux-simple-starter@1.0.0 test /Users/llewellynthomas/learning/ReduxSimpleStarter
> mocha --compilers js:babel-core/register --require ./test/test_helper.js --recursive ./test

/Users/llewellynthomas/learning/ReduxSimpleStarter/node_modules/select2/dist/js/select2.js:5656
  if ($.fn.select2 == null) {
          ^

TypeError: Cannot read property 'select2' of undefined
    at /Users/llewellynthomas/learning/ReduxSimpleStarter/node_modules/select2/dist/js/select2.js:5656:11
    at main (/Users/llewellynthomas/learning/ReduxSimpleStarter/node_modules/select2/dist/js/select2.js:345:39)
    at callDep (/Users/llewellynthomas/learning/ReduxSimpleStarter/node_modules/select2/dist/js/select2.js:211:18)
    at Object.req [as require] (/Users/llewellynthomas/learning/ReduxSimpleStarter/node_modules/select2/dist/js/select2.js:376:20)
    at /Users/llewellynthomas/learning/ReduxSimpleStarter/node_modules/select2/dist/js/select2.js:5716:20
    at S2 (/Users/llewellynthomas/learning/ReduxSimpleStarter/node_modules/select2/dist/js/select2.js:14:5)
    at Object.<anonymous> (/Users/llewellynthomas/learning/ReduxSimpleStarter/node_modules/select2/dist/js/select2.js:19:2)
    at Module._compile (module.js:571:32)
```

Only difference here is that I've add Select2 to package and imported it into app.js

https://www.npmjs.com/package/react-select2-wrapper

https://github.com/rkit/react-select2-wrapper/tree/master/guide